### PR TITLE
Kq adding category create method

### DIFF
--- a/rareapi/views/categories.py
+++ b/rareapi/views/categories.py
@@ -22,3 +22,16 @@ class CategoryViewSet(viewsets.ViewSet):
             return Response(serializer.data)
         except Category.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
+        
+    def create(self, request):
+        label = request.data.get('label')
+
+        # creating the actual post
+        post = Category.objects.create(
+            label=label
+        )
+
+        # For a future many to many, code can be placed here if needed
+
+        serializer = CategorySerializer(post, context={'request': request})
+        return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
I added changes to the `categories.py` module where  `CategoryViewSet` now has a `create` method for handling back-end `POST` operations.

##NOTE: There will be a follow-on PR in the client side


##No tests Required

1) Within the `kq-addingCategoryCreateMethod` , `categories.py` module, `CategoryViewSet` you will see the added `def create` that supports back-end POST for a new `category`