### PR TITLE
see comment

### DIFF
--- a/rareapi/views/posts.py
+++ b/rareapi/views/posts.py
@@ -80,3 +80,31 @@ class PostViewSet(viewsets.ViewSet):
 
         serializer = PostSerializer(post, context={'request': request})
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+    
+    def update(self, request, pk=None):
+        
+        try:
+
+            post = Post.objects.get(pk=pk)
+           
+
+          
+            self.check_object_permissions(request, post)
+
+            serializer = PostSerializer(data=request.data)
+            if serializer.is_valid():
+                post.user = request.auth.user
+                post.title = serializer.validated_data['title']
+                post.content = serializer.validated_data['content']
+                category_id = request.data["category"]["id"]
+                post.category = Category.objects.get(pk=category_id)
+                post.image_url = serializer.validated_data['image_url']
+                post.save()
+
+                serializer = PostSerializer(post, context={'request': request})
+                return Response(None, status.HTTP_202_ACCEPTED)
+
+            return Response(serializer.errors, status.HTTP_400_BAD_REQUEST)
+
+        except Post.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
I created a `def update` method within `posts.py` that supports server side PUT method on a `post`

### Steps to Test
1) Pull down the `kq-editPost` branch
2)Ensure debugger is running
3) head to postman, and make selections on postman to support a PUT
4) recommend on a separate tab, making a `GET` of all posts so you can see what is available to edit
5) in the `PUT` url, ensure you have an id: http://localhost:8000/posts/1
5) in the `PUT` body, here is an example of formatting: {     
     "user": {
            "id": 1,
            "author": "Kevin Quail"
        },
     "title": "This cat is crazy looking",
     "content": "I love cats LOLz",
    "category": {"id": 11, "label": "Humors"},
     "image_url": "https://d.newsweek.com/en/full/1920025/cat-its-mouth-open.jpg?w=1600&h=1600&q=88&f=b7a44663e082b8041129616b6b73328d"

}
6) Successful `PUT` will return code: 202
7) make a final `GET` to ensure update was made

## We crushed it these past two weeks team!